### PR TITLE
feat: add library management domain skeleton

### DIFF
--- a/library-service/pom.xml
+++ b/library-service/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.sinogale</groupId>
+        <artifactId>pom-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>library-service</artifactId>
+    <name>library-service</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sinogale</groupId>
+            <artifactId>sz-jpa-spring-boot-starter</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/library-service/src/main/java/com/sinogale/library/domain/Book.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/Book.java
@@ -1,0 +1,64 @@
+package com.sinogale.library.domain;
+
+import com.sinogale.jpa.support.BaseJpaAggregate;
+import com.sinogale.library.domain.event.BookBorrowedEvent;
+import com.sinogale.library.domain.event.BookCreatedEvent;
+import com.sinogale.library.domain.event.BookRemovedEvent;
+import com.sinogale.library.domain.event.BookReturnedEvent;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+/**
+ * Book aggregate root.
+ */
+@Entity
+@Table(name = "books")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Book extends BaseJpaAggregate {
+
+    @Column(nullable = false)
+    private String title;
+
+    private String author;
+
+    @Column(unique = true)
+    private String isbn;
+
+    private String category;
+
+    /**
+     * Shelf or storage location.
+     */
+    private String location;
+
+    private boolean removed;
+
+    public static Book create(String title, String author, String isbn, String category, String location) {
+        Book book = new Book();
+        book.setTitle(title);
+        book.setAuthor(author);
+        book.setIsbn(isbn);
+        book.setCategory(category);
+        book.setLocation(location);
+        book.registerEvent(new BookCreatedEvent(title));
+        return book;
+    }
+
+    public void borrow(Long userId) {
+        registerEvent(new BookBorrowedEvent(getId(), userId));
+    }
+
+    public void returnBack(Long userId) {
+        registerEvent(new BookReturnedEvent(getId(), userId));
+    }
+
+    public void remove() {
+        this.removed = true;
+        registerEvent(new BookRemovedEvent(getId()));
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/domain/LibraryUser.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/LibraryUser.java
@@ -1,0 +1,29 @@
+package com.sinogale.library.domain;
+
+import com.sinogale.jpa.support.BaseJpaAggregate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+/**
+ * Library system user.
+ */
+@Entity
+@Table(name = "library_users")
+@Getter
+@Setter
+@NoArgsConstructor
+public class LibraryUser extends BaseJpaAggregate {
+
+    @Column(nullable = false)
+    private String username;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public enum Role {
+        STUDENT, TEACHER, ADMIN
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/domain/Loan.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/Loan.java
@@ -1,0 +1,51 @@
+package com.sinogale.library.domain;
+
+import com.sinogale.jpa.support.BaseJpaAggregate;
+import com.sinogale.library.domain.event.BookBorrowedEvent;
+import com.sinogale.library.domain.event.BookReturnedEvent;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+/**
+ * Borrow/return record.
+ */
+@Entity
+@Table(name = "loans")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Loan extends BaseJpaAggregate {
+
+    @ManyToOne(optional = false)
+    private Book book;
+
+    @ManyToOne(optional = false)
+    private LibraryUser user;
+
+    @Column(nullable = false)
+    private Instant borrowedAt;
+
+    @Column(nullable = false)
+    private Instant dueAt;
+
+    private Instant returnedAt;
+
+    public static Loan create(Book book, LibraryUser user, Instant dueAt) {
+        Loan loan = new Loan();
+        loan.setBook(book);
+        loan.setUser(user);
+        loan.setBorrowedAt(Instant.now());
+        loan.setDueAt(dueAt);
+        loan.registerEvent(new BookBorrowedEvent(book.getId(), user.getId()));
+        return loan;
+    }
+
+    public void markReturned() {
+        this.returnedAt = Instant.now();
+        registerEvent(new BookReturnedEvent(book.getId(), user.getId()));
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/domain/event/BookBorrowedEvent.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/event/BookBorrowedEvent.java
@@ -1,0 +1,22 @@
+package com.sinogale.library.domain.event;
+
+/**
+ * Event raised when a book is borrowed.
+ */
+public class BookBorrowedEvent {
+    private final Long bookId;
+    private final Long userId;
+
+    public BookBorrowedEvent(Long bookId, Long userId) {
+        this.bookId = bookId;
+        this.userId = userId;
+    }
+
+    public Long getBookId() {
+        return bookId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/domain/event/BookCreatedEvent.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/event/BookCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.sinogale.library.domain.event;
+
+/**
+ * Event published when a book is created.
+ */
+public class BookCreatedEvent {
+    private final String title;
+
+    public BookCreatedEvent(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/domain/event/BookRemovedEvent.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/event/BookRemovedEvent.java
@@ -1,0 +1,16 @@
+package com.sinogale.library.domain.event;
+
+/**
+ * Event raised when a book is removed from collection.
+ */
+public class BookRemovedEvent {
+    private final Long bookId;
+
+    public BookRemovedEvent(Long bookId) {
+        this.bookId = bookId;
+    }
+
+    public Long getBookId() {
+        return bookId;
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/domain/event/BookReturnedEvent.java
+++ b/library-service/src/main/java/com/sinogale/library/domain/event/BookReturnedEvent.java
@@ -1,0 +1,22 @@
+package com.sinogale.library.domain.event;
+
+/**
+ * Event raised when a book is returned.
+ */
+public class BookReturnedEvent {
+    private final Long bookId;
+    private final Long userId;
+
+    public BookReturnedEvent(Long bookId, Long userId) {
+        this.bookId = bookId;
+        this.userId = userId;
+    }
+
+    public Long getBookId() {
+        return bookId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/library-service/src/main/java/com/sinogale/library/repository/BookRepository.java
+++ b/library-service/src/main/java/com/sinogale/library/repository/BookRepository.java
@@ -1,0 +1,7 @@
+package com.sinogale.library.repository;
+
+import com.sinogale.library.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/library-service/src/main/java/com/sinogale/library/repository/LibraryUserRepository.java
+++ b/library-service/src/main/java/com/sinogale/library/repository/LibraryUserRepository.java
@@ -1,0 +1,7 @@
+package com.sinogale.library.repository;
+
+import com.sinogale.library.domain.LibraryUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LibraryUserRepository extends JpaRepository<LibraryUser, Long> {
+}

--- a/library-service/src/main/java/com/sinogale/library/repository/LoanRepository.java
+++ b/library-service/src/main/java/com/sinogale/library/repository/LoanRepository.java
@@ -1,0 +1,7 @@
+package com.sinogale.library.repository;
+
+import com.sinogale.library.domain.Loan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoanRepository extends JpaRepository<Loan, Long> {
+}

--- a/library-service/src/main/java/com/sinogale/library/service/LibraryService.java
+++ b/library-service/src/main/java/com/sinogale/library/service/LibraryService.java
@@ -1,0 +1,45 @@
+package com.sinogale.library.service;
+
+import com.sinogale.library.domain.Book;
+import com.sinogale.library.domain.LibraryUser;
+import com.sinogale.library.domain.Loan;
+import com.sinogale.library.repository.BookRepository;
+import com.sinogale.library.repository.LibraryUserRepository;
+import com.sinogale.library.repository.LoanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+/**
+ * Application service exposing basic library operations.
+ */
+@Service
+@RequiredArgsConstructor
+public class LibraryService {
+
+    private final BookRepository bookRepository;
+    private final LibraryUserRepository userRepository;
+    private final LoanRepository loanRepository;
+
+    public Book addBook(String title, String author, String isbn, String category, String location) {
+        Book book = Book.create(title, author, isbn, category, location);
+        return bookRepository.save(book);
+    }
+
+    public Loan borrowBook(Long bookId, Long userId, Instant dueAt) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new IllegalArgumentException("Book not found"));
+        LibraryUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Loan loan = Loan.create(book, user, dueAt);
+        return loanRepository.save(loan);
+    }
+
+    public Loan returnBook(Long loanId) {
+        Loan loan = loanRepository.findById(loanId)
+                .orElseThrow(() -> new IllegalArgumentException("Loan not found"));
+        loan.markReturned();
+        return loanRepository.save(loan);
+    }
+}

--- a/library-service/src/test/java/com/sinogale/library/domain/BookTest.java
+++ b/library-service/src/test/java/com/sinogale/library/domain/BookTest.java
@@ -1,0 +1,18 @@
+package com.sinogale.library.domain;
+
+import com.sinogale.library.domain.event.BookBorrowedEvent;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BookTest {
+
+    @Test
+    public void borrowRegistersDomainEvent() {
+        Book book = Book.create("title", "author", "isbn", "cat", "loc");
+        book.clearDomainEvents();
+        book.borrow(1L);
+        assertEquals(1, book.domainEvents().size());
+        assertTrue(book.domainEvents().get(0) instanceof BookBorrowedEvent);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>sz-boot-starters</module>
         <module>sz-codegen</module>
         <module>sz-commons</module>
+        <module>library-service</module>
     </modules>
     <!--  <repositories>-->
     <!--    <repository>-->


### PR DESCRIPTION
## Summary
- scaffold library-service module for school library management
- implement Book, LibraryUser, Loan aggregates with domain events
- provide basic repositories and application service

## Testing
- `mvn -q -pl library-service -am test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a538751c288320b86224fb2df1f568